### PR TITLE
Quote file names since they are used in shell commands

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -8,7 +8,7 @@ import sublime_plugin
 
 log = logging.getLogger(__name__)
 
-ANSIBLE_COMMAND_TEMPLATE = 'ansible-vault {vault_password} {command} {vault_file}'
+ANSIBLE_COMMAND_TEMPLATE = 'ansible-vault {vault_password} {command} "{vault_file}"'
 
 
 def get_setting(key, default=None):
@@ -64,7 +64,7 @@ class AnsibleVaultBase:
         password_input = password
 
         if password_from_file is True:
-            vault_password_flag = '--vault-password-file {}'.format(password)
+            vault_password_flag = '--vault-password-file "{}"'.format(password)
             password_input = ''
 
         proc = subprocess.Popen([


### PR DESCRIPTION
I have some vault files whose full paths contain spaces, so I noticed the file names in the command line weren't quoted. This corrects that. Thanks for this useful code!